### PR TITLE
control-center: Don't suggest gconf

### DIFF
--- a/ukui-control-center/debian/changelog
+++ b/ukui-control-center/debian/changelog
@@ -1,5 +1,5 @@
 ukui-control-center (1.0.0-0ubuntu1) zesty; urgency=medium
 
-  * Initial release. (LP:#1664244)
+  * Initial release. (LP: #1664244)
 
  -- handsome_feng <jianfengli@ubuntukylin.com>  Mon, 06 Mar 2017 14:09:45 +0800

--- a/ukui-control-center/debian/control
+++ b/ukui-control-center/debian/control
@@ -61,7 +61,6 @@ Depends: ${shlibs:Depends},
          libglib2.0-bin,
          mate-power-manager,
          mate-media
-Suggests: gconf2
 Description: utilities to configure the UKUI desktop
  The UKUI control center contains configuration applets for the UKUI desktop,
  allowing to set accessibility configuration, desktop fonts, keyboard

--- a/ukui-desktop-environment/debian/changelog
+++ b/ukui-desktop-environment/debian/changelog
@@ -1,5 +1,5 @@
 ukui-desktop-environment (1.0.0) zesty; urgency=medium
 
-  * Initial release. (LP:#1663477)
+  * Initial release. (LP: #1663477)
 
  -- handsome_feng <jianfengli@ubuntukylin.com>  Mon, 06 Mar 2017 10:17:34 +0800

--- a/ukui-desktop-environment/debian/control
+++ b/ukui-desktop-environment/debian/control
@@ -25,17 +25,8 @@ Depends: peony,
          mate-polkit,
          mate-settings-daemon,
          gnome-terminal,
-         ubuntukylin-theme (>= 1.7.0),
+         ubuntukylin-theme (>= 1.6.2),
          ${misc:Depends},
-Conflicts: mate-conf,
-           mate-conf-editor,
-           mate-dialogs,
-           mate-dialogs-common,
-           mate-dialogs-dbg,
-           mate-doc-utils,
-           mate-doc-utils-gnome,
-           mate-keyring,
-           mate-gnome-main-menu-applet,
 Description: UKUI Desktop Environment (essential components, metapackage)
  The UKUI Desktop Environment is the continuation of MATE. It provides an
  intuitive and attractive desktop environment using traditional metaphors for
@@ -66,9 +57,9 @@ Recommends: evince,
             ukui-screensaver,
             mate-utils,
             gedit,
-Suggests: mail-reader | icedove,
+Suggests: mail-reader | thunderbird,
           network-manager-gnome,
-          x-www-browser | iceweasel,
+          x-www-browser | firefox,
 Description: UKUI Desktop Environment (metapackage)
  The UKUI Desktop Environment is the continuation of MATE. It provides an
  intuitive and attractive desktop environment using traditional metaphors for


### PR DESCRIPTION
These are the two very minor tweaks I made before uploading ukui-control-center to zesty's new queue.

gconf is obsolete and is no longer installed by default in Ubuntu.

Ubuntu Kylin should not [install](https://code.launchpad.net/~jbicha/indicator-china-weather/update-dependencies/+merge/318971) it by default either.